### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # repl.it
 Codes written in repl.it (https://repl.it)
+[![Run on Repl.it](https://repl.it/badge/github/mintcherry/repl.it)](https://repl.it/github/mintcherry/repl.it)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@mintcherry/replit).